### PR TITLE
Add support for CMake components.

### DIFF
--- a/examples/swig/src/mymath.cpp
+++ b/examples/swig/src/mymath.cpp
@@ -1,5 +1,7 @@
 #include "mymath.h"
 
+#include <algorithm>
+#include <stdexcept>
 #include <cmath>
 #include <functional>
 #include <numeric>

--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -56,11 +56,11 @@ class BuildExtension(build_ext):
 
         # Check that CMake is installed
         if shutil.which("cmake") is None:
-            raise RuntimeError(f"Required command 'cmake' not found")
+            raise RuntimeError("Required command 'cmake' not found")
 
         # Check that Ninja is installed
         if shutil.which("ninja") is None:
-            raise RuntimeError(f"Required command 'ninja' not found")
+            raise RuntimeError("Required command 'ninja' not found")
 
         for ext in cmake_extensions:
             self.build_extension(ext)
@@ -101,7 +101,7 @@ class BuildExtension(build_ext):
 
         # CMake configure arguments
         configure_args = [
-            f"-GNinja",
+            "-GNinja",
             f"-DCMAKE_BUILD_TYPE={ext.cmake_build_type}",
             f"-DCMAKE_INSTALL_PREFIX:PATH={cmake_install_prefix}",
         ]
@@ -154,16 +154,18 @@ class BuildExtension(build_ext):
         build_command = ['cmake', '--build', build_folder] + build_args
 
         # 3. Compose CMake install command
-        install_command = ['cmake', '--build', build_folder, '--target', install_target]
+        install_command = ['cmake', '--install', build_folder]
+        if ext.cmake_component is not None:
+            install_command.extend(['--component', ext.cmake_component])
 
-        print(f"")
-        print(f"==> Configuring:")
+        print("")
+        print("==> Configuring:")
         print(f"$ {' '.join(configure_command)}")
-        print(f"")
-        print(f"==> Building:")
+        print("")
+        print("==> Building:")
         print(f"$ {' '.join(build_command)}")
-        print(f"")
-        print(f"==> Installing:")
+        print("")
+        print("==> Installing:")
         print(f"$ {' '.join(install_command)}")
         print("")
 

--- a/src/cmake_build_extension/cmake_extension.py
+++ b/src/cmake_build_extension/cmake_extension.py
@@ -14,6 +14,8 @@ class CMakeExtension(Extension):
         disable_editable: Skip this extension in editable mode.
         source_dir: The location of the main CMakeLists.txt.
         cmake_build_type: The default build type of the CMake project.
+        cmake_component: The name of component to install. Defaults to all
+            components.
         cmake_depends_on: List of dependency packages containing required CMake projects.
     """
 
@@ -24,6 +26,7 @@ class CMakeExtension(Extension):
                  cmake_configure_options: List[str] = (),
                  source_dir: str = str(Path(".").absolute()),
                  cmake_build_type: str = "Release",
+                 cmake_component: str = None,
                  cmake_depends_on: List[str] = ()):
 
         super().__init__(name=name, sources=[])
@@ -40,3 +43,4 @@ class CMakeExtension(Extension):
         self.cmake_depends_on = cmake_depends_on
         self.source_dir = str(Path(source_dir).absolute())
         self.cmake_configure_options = cmake_configure_options
+        self.cmake_component = cmake_component


### PR DESCRIPTION
This enables selecting a subset of components to install to the install
prefix.

This prevents additional SWIG generated files from being copied.  Compare the outputs from swig and swig_components:
swig:
```
adding 'mymath/_bindings.so' 
adding 'mymath/bindings.py'
adding 'mymath/include/mymath.h'          
adding 'mymath/lib/libmymath.a'
adding 'mymath-0.0.0.dist-info/METADATA'
adding 'mymath-0.0.0.dist-info/WHEEL'
adding 'mymath-0.0.0.dist-info/top_level.txt'
adding 'mymath-0.0.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel  
```

swig_components:
```
adding 'mymath/_bindings.so'                                         
adding 'mymath/bindings.py'                                          
adding 'mymath-0.0.0.dist-info/METADATA'
adding 'mymath-0.0.0.dist-info/WHEEL'
adding 'mymath-0.0.0.dist-info/top_level.txt'
adding 'mymath-0.0.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
```