### PR TITLE
Allow creating a top-level `__init__.py` file

### DIFF
--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -174,6 +174,11 @@ class BuildExtension(build_ext):
         subprocess.check_call(build_command)
         subprocess.check_call(install_command)
 
+        # Write content to the top-level __init__.py
+        if ext.write_top_level_init is not None:
+            with open(file=cmake_install_prefix / "__init__.py", mode="w") as f:
+                f.write(ext.write_top_level_init)
+
     @staticmethod
     def extend_cmake_prefix_path(path: str) -> None:
 

--- a/src/cmake_build_extension/cmake_extension.py
+++ b/src/cmake_build_extension/cmake_extension.py
@@ -12,6 +12,8 @@ class CMakeExtension(Extension):
         install_prefix: The path relative to the site-package directory where the CMake
             project is installed (typically the name of the Python package).
         disable_editable: Skip this extension in editable mode.
+        write_top_level_init: Create a new top-level ``__init__.py`` file in the install
+            prefix and write content.
         source_dir: The location of the main CMakeLists.txt.
         cmake_build_type: The default build type of the CMake project.
         cmake_component: The name of component to install. Defaults to all
@@ -23,6 +25,7 @@ class CMakeExtension(Extension):
                  name: str,
                  install_prefix: str,
                  disable_editable: bool = False,
+                 write_top_level_init: str = None,
                  cmake_configure_options: List[str] = (),
                  source_dir: str = str(Path(".").absolute()),
                  cmake_build_type: str = "Release",
@@ -40,6 +43,7 @@ class CMakeExtension(Extension):
         self.install_prefix = install_prefix
         self.cmake_build_type = cmake_build_type
         self.disable_editable = disable_editable
+        self.write_top_level_init = write_top_level_init
         self.cmake_depends_on = cmake_depends_on
         self.source_dir = str(Path(source_dir).absolute())
         self.cmake_configure_options = cmake_configure_options


### PR DESCRIPTION
With this option is possible to write directly from the `CMakeExtension` a top-level `_init__.py` file without relying on the underlying CMake project. It could come handy to package projects with less required upstream changes. At the moment, for most CMake projects, a typical requirement that remains is the possibility to specify a custom installation folder for the bindings.