### PR TITLE
Allow omitting `install_prefix` option if not needed

### DIFF
--- a/src/cmake_build_extension/cmake_extension.py
+++ b/src/cmake_build_extension/cmake_extension.py
@@ -23,7 +23,7 @@ class CMakeExtension(Extension):
 
     def __init__(self,
                  name: str,
-                 install_prefix: str,
+                 install_prefix: str = "",
                  disable_editable: bool = False,
                  write_top_level_init: str = None,
                  cmake_configure_options: List[str] = (),


### PR DESCRIPTION
Depending on the underlying CMake logic, specifying a folder relative to the top-level isolated `site-packages` used during setuptools packaging might be not necessary.