### PR TITLE
Expose CMake binaries

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,9 +59,9 @@ jobs:
         shell: bash
         continue-on-error: ${{ matrix.experimental }}
         run: |
-          cd examples/swig
-          pip install -v .
-          pytest -sv tests
+          pip install numpy
+          pip install --no-build-isolation -v ./examples/swig
+          pytest -sv examples/swig/tests
 
   publish:
     name: 'Publish to PyPI'

--- a/examples/swig/CMakeLists.txt
+++ b/examples/swig/CMakeLists.txt
@@ -26,6 +26,12 @@ target_include_directories(mymath PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+# =======================
+# print_answer executable
+# =======================
+
+add_executable(print_answer src/print_answer.cpp)
+
 # =============
 # SWIG bindings
 # =============
@@ -77,7 +83,7 @@ set_property(
 
 # Install the target with C++ code
 install(
-    TARGETS mymath
+    TARGETS mymath print_answer
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/examples/swig/setup.cfg
+++ b/examples/swig/setup.cfg
@@ -33,3 +33,7 @@ testing =
     pytest-icdiff
 all =
     %(testing)s
+
+[options.entry_points]
+console_scripts =
+    print_answer = mymath.bin.__main__:main

--- a/examples/swig/setup.py
+++ b/examples/swig/setup.py
@@ -22,6 +22,7 @@ setup(
         CMakeExtension(
             name="mymath",
             install_prefix="mymath",
+            expose_binaries=["bin/print_answer"],
             write_top_level_init=init_py,
             source_dir=str(Path(__file__).parent.absolute()),
             cmake_configure_options=[

--- a/examples/swig/src/print_answer.cpp
+++ b/examples/swig/src/print_answer.cpp
@@ -1,0 +1,9 @@
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+    // Answer to the Ultimate Question of Life, the Universe, and Everything
+    std::cout << int('*') << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/examples/swig/tests/test_mymath.py
+++ b/examples/swig/tests/test_mymath.py
@@ -1,11 +1,13 @@
-import pytest
-import numpy as np
+import sys
+
 import mymath.bindings
+import numpy as np
+import pytest
 
 
 def test_dot():
 
-    v1 = [1., 2, 3, -5.5, 42]
+    v1 = [1.0, 2, 3, -5.5, 42]
     v2 = [-3.2, 0, 13, 6, -3.14]
 
     result = mymath.bindings.dot(vector1=v1, vector2=v2)
@@ -14,7 +16,7 @@ def test_dot():
 
 def test_normalize():
 
-    v = [1., 2, 3, -5.5, 42]
+    v = [1.0, 2, 3, -5.5, 42]
 
     result = mymath.bindings.normalize(input=v)
     assert pytest.approx(result) == np.array(v) / np.linalg.norm(v)
@@ -22,7 +24,7 @@ def test_normalize():
 
 def test_dot_numpy():
 
-    v1 = np.array([1., 2, 3, -5.5, 42])
+    v1 = np.array([1.0, 2, 3, -5.5, 42])
     v2 = np.array([-3.2, 0, 13, 6, -3.14])
 
     result = mymath.bindings.dot_numpy(in_1=v1, in_2=v2)
@@ -31,7 +33,7 @@ def test_dot_numpy():
 
 def test_normalize_numpy():
 
-    v = np.array([1., 2, 3, -5.5, 42])
+    v = np.array([1.0, 2, 3, -5.5, 42])
 
     result = mymath.bindings.normalize_numpy(in_1=v)
 
@@ -41,8 +43,24 @@ def test_normalize_numpy():
 
 def test_assertion():
 
-    v1 = np.array([1., 2, 3, -5.5])
-    v2 = np.array([42.])
+    v1 = np.array([1.0, 2, 3, -5.5])
+    v2 = np.array([42.0])
 
     with pytest.raises(RuntimeError):
         _ = mymath.bindings.dot_numpy(in_1=v1, in_2=v2)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="capture_output and text require Python 3.7"
+)
+def test_executable():
+
+    import subprocess
+
+    result = subprocess.run("print_answer", capture_output=True, text=True)
+    assert result.stdout.strip() == "42"
+
+    result = subprocess.run(
+        "python -m mymath.bin print_answer".split(), capture_output=True, text=True
+    )
+    assert result.stdout.strip() == "42"

--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -208,6 +208,11 @@ class BuildExtension(build_ext):
                             binary_path = str(path)
                             break
 
+                        path = Path(str(path) + ".exe")
+                        if path.is_file():
+                            binary_path = str(path)
+                            break
+
                     if not Path(binary_path).is_file():
                         name = binary_path if binary_path != "" else binary_name
                         raise RuntimeError(f"Failed to find binary: {{ name }}")

--- a/src/cmake_build_extension/cmake_extension.py
+++ b/src/cmake_build_extension/cmake_extension.py
@@ -20,6 +20,7 @@ class CMakeExtension(Extension):
         cmake_build_type: The default build type of the CMake project.
         cmake_component: The name of component to install. Defaults to all components.
         cmake_depends_on: List of dependency packages containing required CMake projects.
+        expose_binaries: List of binary paths to expose, relative to top-level directory.
     """
 
     def __init__(
@@ -33,6 +34,7 @@ class CMakeExtension(Extension):
         cmake_build_type: str = "Release",
         cmake_component: str = None,
         cmake_depends_on: List[str] = (),
+        expose_binaries: List[str] = (),
     ):
 
         super().__init__(name=name, sources=[])
@@ -51,3 +53,4 @@ class CMakeExtension(Extension):
         self.source_dir = str(Path(source_dir).absolute())
         self.cmake_configure_options = cmake_configure_options
         self.cmake_component = cmake_component
+        self.expose_binaries = expose_binaries


### PR DESCRIPTION
Fixes #13 

This PR introduces a new `expose_binaries` option that allows specifying a relative path to binaries built with CMake to expose to the Python environment. It is implemented with a generic `__main__.py` magic file that calls the C++ executable.

Projects that want to expose a binary just need to:

1. Use the new option as `expose_binaries=["bin/<executable_name>"]`
2. Create a new entrypoint:
   ```toml
   [options.entry_points]
   console_scripts =
       executable_name = package_name.bin.__main__:main
   ```

Check the SWIG example for a MWE.