### PR TITLE
Omit `.git` folder when packaging the source distribution

### DIFF
--- a/src/cmake_build_extension/sdist_command.py
+++ b/src/cmake_build_extension/sdist_command.py
@@ -142,4 +142,4 @@ class GitSdistFolder(GitSdistABC):
         all_files_gen = Path(repo_root).glob(pattern="**/*")
 
         # Return the list of absolute paths to all the git folder files (also uncommited)
-        return [f for f in all_files_gen if not f.is_dir()]
+        return [f for f in all_files_gen if not f.is_dir() and ".git" not in f.parts]


### PR DESCRIPTION
Otherwise, the sdist archive might become pretty heavy.