### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,6 +20,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - "3.10"
         os:
           - ubuntu-20.04
           - macos-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Build Tools
     Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
The sdist was already supported. This PR builds and publishes a wheel for Python 3.10 and tests the example against it.