### PR TITLE
In example tests, do not assume `python` interpreter

### DIFF
--- a/example/tests/test_pybind11.py
+++ b/example/tests/test_pybind11.py
@@ -64,7 +64,7 @@ def test_executable():
     assert result.stdout.strip() == "42"
 
     result = subprocess.run(
-        "python -m mymath_pybind11.bin print_answer_pybind11".split(),
+        [sys.executable, "-m", "mymath_pybind11.bin", "print_answer_pybind11"],
         capture_output=True,
         text=True,
     )

--- a/example/tests/test_swig.py
+++ b/example/tests/test_swig.py
@@ -61,7 +61,7 @@ def test_executable():
     assert result.stdout.strip() == "42"
 
     result = subprocess.run(
-        "python -m mymath_swig.bin print_answer_swig".split(),
+        [sys.executable, "-m", "mymath_swig.bin", "print_answer_swig"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
Use `sys.executable` instead.

I’m packaging this for Fedora Linux, and I’m building the example project and running its tests in order to test the package at RPM build time. However, in the environment in which the package is built, the Python interpreter is `/usr/bin/python3`; the `python-unversioned-command` package is not installed, and so `/usr/bin/python` is not present. With this PR, the tests can pass no matter what the Python interpreter is named.