### PR TITLE
Add support for parallel build jobs on CMake

### DIFF
--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "wheel",
     "setuptools>=45",
     "setuptools_scm[toml]>=6.0",
-    "cmake_build_extension",
+    # "cmake_build_extension", # EXPERIMENT: It seems that building the examples is downloading the last release instead of using the local copy.
     "numpy",
     "pybind11",
 ]

--- a/example/setup.py
+++ b/example/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
                 "-DEXAMPLE_WITH_PYBIND11:BOOL=OFF",
             ]
             + CIBW_CMAKE_OPTIONS,
+            cmake_parallel_jobs=4,
         ),
         cmake_build_extension.CMakeExtension(
             name="Pybind11Bindings",
@@ -99,6 +100,7 @@ setuptools.setup(
                 "-DEXAMPLE_WITH_PYBIND11:BOOL=ON",
             ]
             + CIBW_CMAKE_OPTIONS,
+            cmake_parallel_jobs=4,
         ),
     ],
     cmdclass=dict(

--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -161,6 +161,10 @@ class BuildExtension(build_ext):
         # CMake build arguments
         build_args = ["--config", ext.cmake_build_type]
 
+        # If CMAKE_BUILD_PARALLEL_LEVEL is not set, apply the corresponding user settings.
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            build_args += [f"-j{ext.cmake_parallel_jobs}"]
+
         if platform.system() == "Windows":
 
             configure_args += []

--- a/src/cmake_build_extension/cmake_extension.py
+++ b/src/cmake_build_extension/cmake_extension.py
@@ -20,6 +20,7 @@ class CMakeExtension(Extension):
         cmake_build_type: The default build type of the CMake project.
         cmake_component: The name of component to install. Defaults to all components.
         cmake_depends_on: List of dependency packages containing required CMake projects.
+        cmake_parallel_jobs: Number of parallel build jobs that CMake can run, defaults to 1.
         expose_binaries: List of binary paths to expose, relative to top-level directory.
     """
 
@@ -34,6 +35,7 @@ class CMakeExtension(Extension):
         cmake_build_type: str = "Release",
         cmake_component: str = None,
         cmake_depends_on: List[str] = (),
+        cmake_parallel_jobs: int = 1,
         expose_binaries: List[str] = (),
     ):
 
@@ -53,4 +55,5 @@ class CMakeExtension(Extension):
         self.source_dir = str(Path(source_dir).absolute())
         self.cmake_configure_options = cmake_configure_options
         self.cmake_component = cmake_component
+        self.cmake_parallel_jobs = cmake_parallel_jobs
         self.expose_binaries = expose_binaries


### PR DESCRIPTION
This should help speed up the builds of projects that have a large number of files that need to be compiled.