### PR TITLE
Fix generated cmake command line argument for generator

### DIFF
--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -151,7 +151,7 @@ class BuildExtension(build_ext):
 
         # Select the appropriate generator and accompanying settings
         if ext.cmake_generator is not None:
-            configure_args += [f"-G \"{ext.cmake_generator}\""]
+            configure_args += ["-G", ext.cmake_generator]
 
             if ext.cmake_generator == "Ninja":
                 # Fix #26: https://github.com/diegoferigo/cmake-build-extension/issues/26


### PR DESCRIPTION
e.g. `-G "Ninja"` is not a valid command line argument and results in the following error:

```
CMake Error: Could not create named generator "Ninja"

Generators
  Green Hills MULTI            = Generates Green Hills MULTI files
                                 (experimental, work-in-progress).
* Unix Makefiles               = Generates standard UNIX makefiles.
  Ninja                        = Generates build.ninja files.
  Ninja Multi-Config           = Generates build-<Config>.ninja files.
  Watcom WMake                 = Generates Watcom WMake makefiles.
  CodeBlocks - Ninja           = Generates CodeBlocks project files.
  CodeBlocks - Unix Makefiles  = Generates CodeBlocks project files.
  CodeLite - Ninja             = Generates CodeLite project files.
  CodeLite - Unix Makefiles    = Generates CodeLite project files.
  Eclipse CDT4 - Ninja         = Generates Eclipse CDT 4.0 project files.
  Eclipse CDT4 - Unix Makefiles= Generates Eclipse CDT 4.0 project files.
  Kate - Ninja                 = Generates Kate project files.
  Kate - Unix Makefiles        = Generates Kate project files.
  Sublime Text 2 - Ninja       = Generates Sublime Text 2 project files.
  Sublime Text 2 - Unix Makefiles
                               = Generates Sublime Text 2 project files.
```

Instead, correctly pass `-G` and the generator as separate arguments.