### PR TITLE
Move reference to unbound local variable into loop

### DIFF
--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -88,11 +88,12 @@ class BuildExtension(build_ext):
         if shutil.which("cmake") is None:
             raise RuntimeError("Required command 'cmake' not found")
 
-        # Check that Ninja is installed
-        if ext.cmake_generator.lower() == "ninja" and shutil.which("ninja") is None:
-            raise RuntimeError("Required command 'ninja' not found")
-
         for ext in cmake_extensions:
+            # Check that Ninja is installed
+            if (ext.cmake_generator and 
+                ext.cmake_generator.lower() == "ninja" and 
+                shutil.which("ninja") is None):
+                raise RuntimeError("Required command 'ninja' not found")
 
             # Disable the extension if specified in the command line
             if (


### PR DESCRIPTION
Got this error on a windows VS build. Moving this into the loop over `cmake_extensions` avoids the unbound local error and also handles the case where `cmake_generator` is `None`.

```
      File "C:\Users\douglasc\AppData\Local\Temp\pip-build-env-sm21v1a3\overlay\Lib\site-packages\cmake_build_extension\build_extension.py", line 92, in run
          if ext.cmake_generator.lower() == "ninja" and shutil.which("ninja") is None:
      UnboundLocalError: local variable 'ext' referenced before assignment
      [end of output]
```