### PR TITLE
Support GNU/Hurd as build platform

### DIFF
--- a/src/cmake_build_extension/build_extension.py
+++ b/src/cmake_build_extension/build_extension.py
@@ -177,7 +177,7 @@ class BuildExtension(build_ext):
 
             configure_args += []
 
-        elif platform.system() in {"Linux", "Darwin"}:
+        elif platform.system() in {"Linux", "Darwin", "GNU"}:
 
             configure_args += []
 


### PR DESCRIPTION
Nothing particular to do, other than recognizing the platform; cmake works just fine already.