### PR TITLE
Fix setuptools_scm Configuration import

### DIFF
--- a/src/cmake_build_extension/sdist_command.py
+++ b/src/cmake_build_extension/sdist_command.py
@@ -29,11 +29,11 @@ class GitSdistABC(abc.ABC, setuptools.command.sdist.sdist):
         specifying a list of files that are copied in the location of the setup.cfg.
         """
 
-        import setuptools_scm.integration
+        import setuptools_scm
 
         # Build the setuptools_scm configuration, containing useful info for the sdist
-        config: setuptools_scm.integration.Configuration = (
-            setuptools_scm.integration.Configuration.from_file(
+        config: setuptools_scm.Configuration = (
+            setuptools_scm.Configuration.from_file(
                 dist_name=self.distribution.metadata.name
             )
         )


### PR DESCRIPTION
The `Configuration` class gets imported from `setuptools_scm.integration` for some reason. This causes issues with `setuptools_scm>=8`, because it's not available in that module anymore.

`Configuration` is defined in `setuptools_scm._config` (`setuptools_scm.config` in older versions), but has always been available in the global `setuptools_scm` namespace from what I can tell, so that is where it should be imported from. (Why it is being imported from `setuptools_scm.integration` is beyond me, my guess is IDE autocomplete is to blame here.)